### PR TITLE
add `/image` endpoint to pull new images triggered by webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ SECRET=YOUR_GITHUB_WEBHOOK_SECRET
 BUILD_URL=https://test.skohub.io/build
 DOCKER_IMAGE=skohub/skohub-vocabs-docker
 DOCKER_TAG=latest
+PULL_IMAGE_SECRET=ThisIsATest

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 public/
 dist/**/*.json
 .env
+test/generateSignature.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules/
 public/
 dist/**/*.json
 .env
-test/generateSignature.js

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In order to wire this up with GitHub, this has to be available to the public. Yo
 
 ## Restarting or Rebuilding the webhook server
 
-To restart and rebuild the service, e.g. after a `git pull` do `docker-compose up --build --force-recreate`.
+To restart and rebuild the service, e.g. after a `git pull` do `docker compose up --build --force-recreate`.
 
 ## Connecting to our webhook server
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ The `images` volume is used to save the downloaded docker images, so the are per
 
 The webhook server allows to trigger a build when vocabularies are updated (i.e. changes are merged into the `main` branch) on GitHub.
 
-Running `docker compose up` will start the server on the defined `PORT` and expose a `build` endpoint.
+Running `docker compose up` will start the server on the defined `PORT` and expose the `/build` and `/image` endpoints.
 Add `-d` flag to run in detached mode.
 Use `docker compose logs` to see the logs (add `-f` to follow).
 In order to wire this up with GitHub, this has to be available to the public. You can then configure the webhook in your GitHub repositories settings:
 
 ![image](https://user-images.githubusercontent.com/149825/62695510-c756b880-b9d6-11e9-86a9-0c4dcd6bc2cd.png)
+
+## Restarting or Rebuilding the webhook server
 
 To restart and rebuild the service, e.g. after a `git pull` do `docker-compose up --build --force-recreate`.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Run the test script in a separate terminal with `npm run test:docker`.
 
 ### Test the `/build` endpoint
 
-Here is an example Curl to test the image endpoint with `SECRET=ThisIsATest`:
+Here is an example Curl to test the build endpoint with `SECRET=ThisIsATest`:
 
 ```bash
 curl --request POST \

--- a/README.md
+++ b/README.md
@@ -19,14 +19,25 @@ The `.env` file contains configuration details used by the static site generator
 - `BUILD_URL`: URL of the build page. This URL with a specific ID for each build can be used to retrieve information about success or errors of a triggered build. 
 - `DOCKER_IMAGE`: The docker image which should be used to build the vocabulary, defaults to `skohub/skohub-vocabs-docker`
 - `DOCKER_TAG`: The docker tag for the `DOCKER_IMAGE`, defaults to `latest`
+- `PULL_IMAGE_SECRET`: The secret needed for the `/image` endpoint to trigger the pull of new images via webhook.
 
 ## How does it work?
+
+### `/build`
 
 The webhook server is based on Koa and exposes a `build` endpoint listening to a `POST`-request.
 When a request is reveived and the SECRET matches, a build is triggered.
 This will make use of the `skohub-vocabs-docker` image (or some other image you defined in `.env`) and build HTML pages out of the provided SKOS files.
 The resulting pages are then copied to the `dist` directory, while using the repository and ref informations to build the paths to avoid paths conflicts (e.g. `dist/sroertgen/test-vocabs/heads/main`).
 This directory can then be served from a webserver like Apache.
+
+### `/image`
+
+The webhook server pulls the in `.env` defined image when it starts.
+To always build with the most recent image, you can trigger the `image` endpoint with a `POST`-request.
+The request is triggered by a GitHub Webhook when the [`docker` workflow_job](https://github.com/skohub-io/skohub-vocabs/blob/master/.github/workflows/main.yml) completes.
+You can set up the webhook in the skohub-vocabs repo and choose "Workflow jobs" as event type.
+The secret has to match the `PULL_IMAGE_SECRET` from `.env`.
 
 ### How does it work in detail?
 
@@ -70,6 +81,49 @@ Run both with `npm run test`.
 To test the docker setup change the secret in `.env` to `SECRET=ThisIsATest`
 Then start the service with `docker compose up`.
 Run the test script in a separate terminal with `npm run test:docker`.
+
+### Test the `/build` endpoint
+
+Here is an example Curl to test the image endpoint with `SECRET=ThisIsATest`:
+
+```bash
+curl --request POST \
+  --url http://localhost:3000/build \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'x-github-event: push' \
+  --header 'x-github-token: ThisIsATest' \
+  --header 'x-hub-signature: sha1=76cf6b20692888081b4e7e2e3cc57c7dbe034049' \
+  --data '{
+  "ref": "refs/heads/main",
+  "repository": {
+    "full_name": "sroertgen/test-vocabs"
+  }
+}'
+```
+
+### Test the `/image` endpoint
+
+Here is an example Curl to test the image endpoint with `PULL_IMAGE_SECRET=ThisIsATest`:
+
+```bash
+curl --request POST \
+  --url http://localhost:3000/image \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'x-github-event: workflow_job' \
+  --header 'x-github-token: ThisIsATest' \
+  --header 'x-hub-signature: sha1=4f7bf1daf9b62eb38c568ed17d3371917cbc565f' \
+  --data '{
+  "action": "completed",
+	"repository": {
+		"full_name": "test/testing"
+	},
+	"ref": "refs/heads/master",
+	"workflow_job": "docker"
+}'
+
+```
 
 ## Credits
 

--- a/src/common.js
+++ b/src/common.js
@@ -72,7 +72,7 @@ const isValid = (hook, event) => {
     ) // Has a valid ref
   } else if (event === "workflow_job") {
     return (
-      isCompletedWorkflowJob === true && // Only accept push request
+      isCompletedWorkflowJob === true && // Only accept completed workflow job
       repository !== null &&
       /^[^/]+\/[^/]+$/.test(repository) && // Has a valid repository
       ref !== null &&


### PR DESCRIPTION
This PR adds an `/image` endpoint to the webhook server.
It is configured to listen to POST requests that should be triggered by a GitHub Webhook when a given workflow_job completes. In our case the `workflow_job` is `docker`, because that indicates that a new image was built in the skohub-vocabs repo ( see [GitHub Actions of SkoHub Vocabs](https://github.com/skohub-io/skohub-vocabs/blob/871f0c5c84353057b18d455b8c8ee702251c97cc/.github/workflows/main.yml#L74) ).

See also here for documentation about `workflow_job` events and webhooks: https://docs.github.com/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_job

It is a bit difficult to test this locally. GitHub provides a commandline tool to test: https://docs.github.com/en/developers/webhooks-and-events/webhooks/receiving-webhooks-with-the-github-cli
But this is still early and you actually seem to request access to this feature, which I did, but right now access is not yet granted (https://github.com/community/community/discussions/38261#discussioncomment-4819402).

However, to test locally I added some documentation about curls in the documentation.

I also added some tests for this new feature.