### PR TITLE
6 folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 public/
 dist/**/*.json
 .env
+
+# Code Editor
+.vscode/launch.json


### PR DESCRIPTION
Vocabularies in folders are not published (see #6).

I added a function to recursively parse files from GitHub. This fixes the issue (at least for GitHub).

In this repo I added `*.ttl` files in a `test-folder`. 

I suggest that @Phu2 deploys this to test, please assign @acka47 after that.
@acka47 can then trigger a build using my test-repo (https://github.com/sroertgen/test-vocabs), e.g.

```bash
curl --request POST \
  --url http://test.skohub.io/build \
  --header 'Accept: application/json' \
  --header 'Content-Type: application/json' \
  --header 'x-github-event: push' \
  --header 'x-github-token: ThisIsATest' \
  --header 'x-hub-signature: sha1=76cf6b20692888081b4e7e2e3cc57c7dbe034049' \
  --data '{
  "ref": "refs/heads/main",
  "repository": {
    "full_name": "sroertgen/test-vocabs"
  }
}'
```

...or using his own repo.

