### PR TITLE
Adjust stdout parsing so warnings don't throw an error

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -196,6 +196,16 @@ const parseHook = (headers, body, secret) => {
   }
 }
 
+function checkStdOutForError(text) {
+  // SHACL Warning message
+  if (text.includes("-----------warning--------------")) {
+    return false
+  } else if (text.includes("error")) {
+    return true
+  }
+}
+
+
 module.exports = {
   getHeaders,
   getHookGitHub,
@@ -205,4 +215,5 @@ module.exports = {
   isSecured,
   getRepositoryFiles,
   parseHook,
+  checkStdOutForError
 }

--- a/src/server.js
+++ b/src/server.js
@@ -10,7 +10,8 @@ const fetch = require("node-fetch")
 const {
   isValid,
   getRepositoryFiles,
-  parseHook
+  parseHook,
+  checkStdOutForError,
 } = require("./common")
 
 require("dotenv").config()
@@ -202,7 +203,7 @@ const processWebhooks = async () => {
         shell: "/bin/bash",
       })
       build.stdout.on("data", (data) => {
-        if (data.toString().toLowerCase().includes("error")) {
+        if (checkStdOutForError(data.toString().toLowerCase())) {
           webhook.log.push({
             date: new Date(),
             text: data.toString(),


### PR DESCRIPTION
SHACL Warnigs will now no longer be interpreted as errors.